### PR TITLE
Default sax usage to `strict` mode

### DIFF
--- a/lib/xmlnode.js
+++ b/lib/xmlnode.js
@@ -26,7 +26,7 @@ XmlNode.prototype.createSaxParser = function (options) {
 
   var self = this,
   record,
-  parser = sax.parser(false, {
+  parser = sax.parser(true, {
     trim: false,
     normalize: false,
     xmlns: false,

--- a/test/mixedcase.xml
+++ b/test/mixedcase.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MIXEDCASE><ITEM><A><![CDATA[abc]]></A><B><![CDATA[15]]></B></ITEM><item><A><![CDATA[def]]></A><B><![CDATA[16]]></B></item></MIXEDCASE>

--- a/test/xmlnode.js
+++ b/test/xmlnode.js
@@ -41,6 +41,25 @@ describe('xmlnode', function(){
       });
   });
 
+   it('should respect xml tag case', function(done){
+    var result = [];
+
+    fs.createReadStream(__dirname + '/mixedcase.xml')
+      .pipe(xmlnode({
+        tag: 'ITEM'
+      }))
+      .pipe(memory(result))
+      .on('finish', function(err) {
+        result.should.have.length(1);
+        result[0].should.have.property('children');
+        result[0].children.A.should.have.property('value', 'abc');
+        result[0].children.B.should.have.property('value', '15');
+        done(err);
+      });
+  });
+
+ 
+
   it('should parse nodes with attributes when configured', function(done){
     var result = [];
 
@@ -66,19 +85,19 @@ describe('xmlnode', function(){
 
         a[0].should.have.property('value', 'abc');
         a[0].should.have.property('attribs');
-        a[0].attribs.ATTR.should.eql('1');
+        a[0].attribs.attr.should.eql('1');
 
         a[1].should.have.property('value', 'def');
         a[1].should.have.property('attribs');
-        a[1].attribs.ATTR.should.eql('2');
+        a[1].attribs.attr.should.eql('2');
 
         a[2].should.have.property('value', 'ghi');
         a[2].should.have.property('attribs');
-        a[2].attribs.ATTR.should.eql('3');
+        a[2].attribs.attr.should.eql('3');
 
         b.should.have.property('value', '15');
         b.should.have.property('attribs');
-        b.attribs.ATTR.should.eql('4');
+        b.attribs.attr.should.eql('4');
 
         done(err);
       });


### PR DESCRIPTION
I don't know it this PR makes sense for you so I send it to open a discussion.
The default sax parser is in loose mode, where, among other things, tags are all uppercased.

I initially ran into a problem with sax-stream because the example on https://github.com/code42day/sax-stream says 

```
.pipe(saxStream({
   tag: 'item'
})
```

which doesn't work because tags must currently always be uppercased.

Since all tests use UPPERCASE tags in the original xml files, I don't know if you consider the default "loose" mode a bug or a feature.
